### PR TITLE
feat(v2.0.0): Migrate to binary-only license format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 *.dylib
 
 # Project binaries
-licforge
-client-example
+licforge.exe
+client-example.exe
 
 # Test binary, built with `go test -c`
 *.test
@@ -31,13 +31,14 @@ go.work.sum
 
 # Project specific files
 keys/
-*.lic
+license.lic
 
 # IDE specific files
 .idea/
 .vscode/
 *.swp
 *.swo
+*.exe
 
 # OS specific files
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Go License Management System will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-04-29
+
+### Added
+- Binary license format for improved security and smaller file size
+- Automatic hardware detection with `--auto-hardware` flag
+- Backward compatibility for reading and verifying legacy JSON licenses
+
+### Changed
+- Licenses are now generated exclusively in binary format
+- Updated verification to support both binary and legacy JSON formats
+- Improved format detection in the `info` command
+- Updated documentation to reflect the new binary format
+
+### Removed
+- JSON license generation option (only binary format is now supported)
+- Encryption-related code (simplified the codebase)
+
 ## [1.1.0] - 2025-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A powerful open-source license management system built with Go that generates and manages offline-validated, hardware-bound licenses with digital signatures.
 
-**Current Version: 1.1.0**
+**Current Version: 2.0.0**
 
 ## Overview
 
@@ -19,6 +19,8 @@ This project provides a complete solution for software license management with t
 - **Expiration Management**: Set and enforce license expiration dates
 - **Serial Number Tracking**: Unique serial numbers for better license management and tracking
 - **Security-Focused Design**: Clear separation between generation and verification components
+- **Binary License Format**: Licenses are stored in a compact binary format that is not human-readable (v2.0.0+)
+- **Legacy Support**: Maintains backward compatibility with JSON licenses from v1.x
 
 ## Architecture
 
@@ -198,7 +200,34 @@ Options:
 - `-hostnames` - Comma-separated list of hostnames for hardware binding
 - `-key` - Path to private key (default: "keys/private.pem")
 - `-output` - Output license file path (default: "license.lic")
+- `-auto-hardware` - Automatically detect and use current hardware information
 - `-interactive` - Use interactive mode for license generation
+
+### Version 2.0.0 Changes
+
+#### Binary License Format
+
+Starting with version 2.0.0, licenses are generated exclusively in a binary format rather than JSON. This provides several benefits:
+
+- **Improved Security**: Binary licenses are not human-readable in a text editor
+- **Smaller Size**: Binary format produces more compact license files
+- **Tamper Resistance**: Combined with digital signatures, makes licenses more difficult to modify
+
+#### Backward Compatibility
+
+While new licenses are generated only in binary format, the system maintains backward compatibility:
+
+- The verification library can still read and validate legacy JSON licenses from v1.x
+- The `info` command will automatically detect and display information for both binary and legacy JSON licenses
+
+#### Hardware Auto-Detection
+
+Version 2.0.0 adds the ability to automatically detect and use the current machine's hardware information:
+
+```bash
+# Generate a license using current hardware information
+./licforge genlicense -id "LICENSE-001" -customer "Acme Corp" -product "SuperApp" -serial "SN12345" -auto-hardware
+```
 
 ### Interactive License Generation
 

--- a/pkg/integration_binary_test.go
+++ b/pkg/integration_binary_test.go
@@ -1,0 +1,179 @@
+package pkg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luhtfiimanal/go-license/pkg/licgen"
+	"github.com/luhtfiimanal/go-license/pkg/licverify"
+)
+
+func TestBinaryLicenseIntegration(t *testing.T) {
+	// Generate a key pair for testing
+	privateKeyPEM, publicKeyPEM, err := licgen.GenerateKeyPair(2048)
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	// Parse the private key
+	privateKey, err := licgen.ParsePrivateKey(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+
+	// Create a license verifier
+	verifier, err := licverify.NewVerifier(publicKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create verifier: %v", err)
+	}
+
+	// Create a test license
+	licenseID := "test-license-binary-123"
+	customerID := "customer-456"
+	productID := "product-789"
+	serialNumber := "SN-ABCDEF"
+	expiryDuration := 365 * 24 * time.Hour // 1 year
+	features := []string{"feature1", "feature2", "feature3"}
+	hardwareIDs := licverify.HardwareBinding{
+		MACAddresses: []string{"00:11:22:33:44:55"},
+		HostNames:    []string{"localhost"},
+	}
+
+	// Generate the license
+	licenseData, err := licgen.GenerateLicense(
+		licenseID,
+		customerID,
+		productID,
+		serialNumber,
+		expiryDuration,
+		features,
+		hardwareIDs,
+		privateKey,
+	)
+	if err != nil {
+		t.Fatalf("Failed to generate license: %v", err)
+	}
+
+	// Create a temporary file for the license
+	tempFile := t.TempDir() + "/test-license.bin"
+
+	// Save the license to a file
+	err = licgen.SaveLicenseToFile(licenseData, tempFile)
+	if err != nil {
+		t.Fatalf("Failed to save license to file: %v", err)
+	}
+
+	// Load the license from the file
+	license, err := verifier.LoadLicense(tempFile)
+	if err != nil {
+		t.Fatalf("Failed to load license: %v", err)
+	}
+
+	// Verify the license fields
+	if license.ID != licenseID {
+		t.Errorf("License ID mismatch: expected %s, got %s", licenseID, license.ID)
+	}
+	if license.CustomerID != customerID {
+		t.Errorf("Customer ID mismatch: expected %s, got %s", customerID, license.CustomerID)
+	}
+	if license.ProductID != productID {
+		t.Errorf("Product ID mismatch: expected %s, got %s", productID, license.ProductID)
+	}
+	if license.SerialNumber != serialNumber {
+		t.Errorf("Serial number mismatch: expected %s, got %s", serialNumber, license.SerialNumber)
+	}
+
+	// Verify the license signature
+	err = verifier.VerifySignature(license)
+	if err != nil {
+		t.Errorf("Signature verification failed: %v", err)
+	}
+
+	// Verify the license expiry
+	err = verifier.VerifyExpiry(license)
+	if err != nil {
+		t.Errorf("Expiry verification failed: %v", err)
+	}
+
+	// Skip hardware binding verification in tests
+	// Just verify signature and expiry separately
+	err = verifier.VerifySignature(license)
+	if err != nil {
+		t.Errorf("Signature verification failed: %v", err)
+	}
+
+	err = verifier.VerifyExpiry(license)
+	if err != nil {
+		t.Errorf("Expiry verification failed: %v", err)
+	}
+}
+
+func TestBinaryLicenseTampering(t *testing.T) {
+	// Generate a key pair for testing
+	privateKeyPEM, publicKeyPEM, err := licgen.GenerateKeyPair(2048)
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	// Parse the private key
+	privateKey, err := licgen.ParsePrivateKey(privateKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+
+	// Create a license verifier
+	verifier, err := licverify.NewVerifier(publicKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create verifier: %v", err)
+	}
+
+	// Create a test license
+	licenseID := "test-license-binary-456"
+	customerID := "customer-789"
+	productID := "product-123"
+	serialNumber := "SN-XYZABC"
+	expiryDuration := 365 * 24 * time.Hour // 1 year
+	features := []string{"feature1", "feature2", "feature3"}
+	hardwareIDs := licverify.HardwareBinding{
+		MACAddresses: []string{"00:11:22:33:44:55"},
+		HostNames:    []string{"localhost"},
+	}
+
+	// Generate the license
+	licenseData, err := licgen.GenerateLicense(
+		licenseID,
+		customerID,
+		productID,
+		serialNumber,
+		expiryDuration,
+		features,
+		hardwareIDs,
+		privateKey,
+	)
+	if err != nil {
+		t.Fatalf("Failed to generate license: %v", err)
+	}
+
+	// Create a temporary file for the license
+	tempFile := t.TempDir() + "/test-license-tampered.bin"
+
+	// Tamper with the license data (change a byte in the middle)
+	midPoint := len(licenseData) / 2
+	licenseData[midPoint] = licenseData[midPoint] ^ 0xFF // Flip all bits
+
+	// Save the tampered license to a file
+	err = licgen.SaveLicenseToFile(licenseData, tempFile)
+	if err != nil {
+		t.Fatalf("Failed to save license to file: %v", err)
+	}
+
+	// Try to load the tampered license
+	license, err := verifier.LoadLicense(tempFile)
+	if err == nil {
+		// If we can load it, the signature should fail
+		err = verifier.VerifySignature(license)
+		if err == nil {
+			t.Errorf("Expected signature verification to fail for tampered license, but it succeeded")
+		}
+	}
+}

--- a/pkg/licformat/adapter.go
+++ b/pkg/licformat/adapter.go
@@ -1,0 +1,83 @@
+package licformat
+
+import (
+	"time"
+)
+
+// LicenseAdapter provides functions to convert between license types
+// without creating import cycles between packages
+
+// License represents the structure of a license from the licverify package
+// This is a copy of the struct to avoid import cycles
+type License struct {
+	ID           string
+	CustomerID   string
+	ProductID    string
+	SerialNumber string
+	IssueDate    time.Time
+	ExpiryDate   time.Time
+	Features     []string
+	HardwareIDs  HardwareBinding
+	Signature    []byte
+}
+
+// HardwareBinding is a copy of the struct from licverify
+type HardwareBinding struct {
+	MACAddresses []string
+	DiskIDs      []string
+	HostNames    []string
+	CustomIDs    []string
+}
+
+// ToLicenseData converts a License to LicenseData
+func ToLicenseData(license *License) *LicenseData {
+	return &LicenseData{
+		ID:           license.ID,
+		CustomerID:   license.CustomerID,
+		ProductID:    license.ProductID,
+		SerialNumber: license.SerialNumber,
+		IssueDate:    license.IssueDate,
+		ExpiryDate:   license.ExpiryDate,
+		Features:     license.Features,
+		HardwareIDs: HardwareBindingData{
+			MACAddresses: license.HardwareIDs.MACAddresses,
+			DiskIDs:      license.HardwareIDs.DiskIDs,
+			HostNames:    license.HardwareIDs.HostNames,
+			CustomIDs:    license.HardwareIDs.CustomIDs,
+		},
+	}
+}
+
+// FromLicenseData converts LicenseData to a License
+func FromLicenseData(data *LicenseData) *License {
+	return &License{
+		ID:           data.ID,
+		CustomerID:   data.CustomerID,
+		ProductID:    data.ProductID,
+		SerialNumber: data.SerialNumber,
+		IssueDate:    data.IssueDate,
+		ExpiryDate:   data.ExpiryDate,
+		Features:     data.Features,
+		HardwareIDs: HardwareBinding{
+			MACAddresses: data.HardwareIDs.MACAddresses,
+			DiskIDs:      data.HardwareIDs.DiskIDs,
+			HostNames:    data.HardwareIDs.HostNames,
+			CustomIDs:    data.HardwareIDs.CustomIDs,
+		},
+	}
+}
+
+// EncodeLicense converts a License to binary format
+func EncodeLicense(license *License) ([]byte, error) {
+	data := ToLicenseData(license)
+	return EncodeLicenseData(data)
+}
+
+// DecodeLicense converts binary data to a License
+func DecodeLicense(data []byte) (*License, error) {
+	licenseData, err := DecodeLicenseData(data)
+	if err != nil {
+		return nil, err
+	}
+	return FromLicenseData(licenseData), nil
+}

--- a/pkg/licformat/binary.go
+++ b/pkg/licformat/binary.go
@@ -1,0 +1,208 @@
+package licformat
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"time"
+)
+
+// BinaryFormat implements a binary serialization format for licenses
+// This is an internal implementation that doesn't change the public API
+
+// Format version to ensure compatibility
+const currentVersion byte = 1
+
+// Header for the binary format
+type header struct {
+	Version byte
+	Length  uint32 // Length of the license data (excluding signature)
+}
+
+// LicenseData holds the data for a license in a format-agnostic way
+type LicenseData struct {
+	ID           string
+	CustomerID   string
+	ProductID    string
+	SerialNumber string
+	IssueDate    time.Time
+	ExpiryDate   time.Time
+	Features     []string
+	HardwareIDs  HardwareBindingData
+}
+
+// HardwareBindingData contains hardware identifiers for license binding
+type HardwareBindingData struct {
+	MACAddresses []string
+	DiskIDs      []string
+	HostNames    []string
+	CustomIDs    []string
+}
+
+// EncodeLicenseData converts license data to binary format
+func EncodeLicenseData(data *LicenseData) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// Write header placeholder (will update length later)
+	h := header{Version: currentVersion, Length: 0}
+	if err := binary.Write(&buf, binary.LittleEndian, h); err != nil {
+		return nil, err
+	}
+	headerSize := buf.Len()
+
+	// Write license fields
+	writeString(&buf, data.ID)
+	writeString(&buf, data.CustomerID)
+	writeString(&buf, data.ProductID)
+	writeString(&buf, data.SerialNumber)
+
+	// Write timestamps
+	binary.Write(&buf, binary.LittleEndian, data.IssueDate.Unix())
+	binary.Write(&buf, binary.LittleEndian, data.ExpiryDate.Unix())
+
+	// Write features
+	writeStringSlice(&buf, data.Features)
+
+	// Write hardware binding
+	writeStringSlice(&buf, data.HardwareIDs.MACAddresses)
+	writeStringSlice(&buf, data.HardwareIDs.DiskIDs)
+	writeStringSlice(&buf, data.HardwareIDs.HostNames)
+	writeStringSlice(&buf, data.HardwareIDs.CustomIDs)
+
+	// Update header with correct length
+	bytes := buf.Bytes()
+	binary.LittleEndian.PutUint32(bytes[1:5], uint32(len(bytes)-headerSize))
+
+	return bytes, nil
+}
+
+// DecodeLicenseData converts binary data back to license data
+func DecodeLicenseData(data []byte) (*LicenseData, error) {
+	if len(data) < 5 { // Minimum size for header
+		return nil, errors.New("data too small to be a valid license")
+	}
+
+	buf := bytes.NewReader(data)
+
+	// Read header
+	var h header
+	if err := binary.Read(buf, binary.LittleEndian, &h); err != nil {
+		return nil, err
+	}
+
+	// Check version
+	if h.Version != currentVersion {
+		return nil, errors.New("unsupported license format version")
+	}
+
+	licenseData := &LicenseData{}
+
+	// Read license fields
+	var err error
+	licenseData.ID, err = readString(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.CustomerID, err = readString(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.ProductID, err = readString(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.SerialNumber, err = readString(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read timestamps
+	var issueUnix, expiryUnix int64
+	if err := binary.Read(buf, binary.LittleEndian, &issueUnix); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(buf, binary.LittleEndian, &expiryUnix); err != nil {
+		return nil, err
+	}
+	licenseData.IssueDate = time.Unix(issueUnix, 0)
+	licenseData.ExpiryDate = time.Unix(expiryUnix, 0)
+
+	// Read features
+	licenseData.Features, err = readStringSlice(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read hardware binding
+	licenseData.HardwareIDs.MACAddresses, err = readStringSlice(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.HardwareIDs.DiskIDs, err = readStringSlice(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.HardwareIDs.HostNames, err = readStringSlice(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	licenseData.HardwareIDs.CustomIDs, err = readStringSlice(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return licenseData, nil
+}
+
+// Helper functions for reading/writing strings and slices
+
+func writeString(buf *bytes.Buffer, s string) {
+	data := []byte(s)
+	binary.Write(buf, binary.LittleEndian, uint16(len(data)))
+	buf.Write(data)
+}
+
+func readString(buf *bytes.Reader) (string, error) {
+	var length uint16
+	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
+		return "", err
+	}
+
+	data := make([]byte, length)
+	if _, err := buf.Read(data); err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func writeStringSlice(buf *bytes.Buffer, slice []string) {
+	binary.Write(buf, binary.LittleEndian, uint16(len(slice)))
+	for _, s := range slice {
+		writeString(buf, s)
+	}
+}
+
+func readStringSlice(buf *bytes.Reader) ([]string, error) {
+	var length uint16
+	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
+		return nil, err
+	}
+
+	result := make([]string, length)
+	for i := 0; i < int(length); i++ {
+		s, err := readString(buf)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = s
+	}
+
+	return result, nil
+}

--- a/pkg/licformat/binary_test.go
+++ b/pkg/licformat/binary_test.go
@@ -1,0 +1,201 @@
+package licformat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBinaryEncodingDecoding(t *testing.T) {
+	// Create a test license data
+	original := &LicenseData{
+		ID:           "test-license-123",
+		CustomerID:   "customer-456",
+		ProductID:    "product-789",
+		SerialNumber: "SN-ABCDEF",
+		IssueDate:    time.Now().Truncate(time.Second), // Truncate to avoid nanosecond precision issues
+		ExpiryDate:   time.Now().AddDate(1, 0, 0).Truncate(time.Second),
+		Features:     []string{"feature1", "feature2", "feature3"},
+		HardwareIDs: HardwareBindingData{
+			MACAddresses: []string{"00:11:22:33:44:55", "AA:BB:CC:DD:EE:FF"},
+			DiskIDs:      []string{"disk-id-1", "disk-id-2"},
+			HostNames:    []string{"host1.example.com", "host2.example.com"},
+			CustomIDs:    []string{"custom-id-1", "custom-id-2"},
+		},
+	}
+
+	// Encode to binary
+	binaryData, err := EncodeLicenseData(original)
+	if err != nil {
+		t.Fatalf("Failed to encode license data: %v", err)
+	}
+
+	// Decode from binary
+	decoded, err := DecodeLicenseData(binaryData)
+	if err != nil {
+		t.Fatalf("Failed to decode license data: %v", err)
+	}
+
+	// Verify all fields match
+	if original.ID != decoded.ID {
+		t.Errorf("ID mismatch: expected %s, got %s", original.ID, decoded.ID)
+	}
+	if original.CustomerID != decoded.CustomerID {
+		t.Errorf("CustomerID mismatch: expected %s, got %s", original.CustomerID, decoded.CustomerID)
+	}
+	if original.ProductID != decoded.ProductID {
+		t.Errorf("ProductID mismatch: expected %s, got %s", original.ProductID, decoded.ProductID)
+	}
+	if original.SerialNumber != decoded.SerialNumber {
+		t.Errorf("SerialNumber mismatch: expected %s, got %s", original.SerialNumber, decoded.SerialNumber)
+	}
+	if !original.IssueDate.Equal(decoded.IssueDate) {
+		t.Errorf("IssueDate mismatch: expected %v, got %v", original.IssueDate, decoded.IssueDate)
+	}
+	if !original.ExpiryDate.Equal(decoded.ExpiryDate) {
+		t.Errorf("ExpiryDate mismatch: expected %v, got %v", original.ExpiryDate, decoded.ExpiryDate)
+	}
+
+	// Check features
+	if len(original.Features) != len(decoded.Features) {
+		t.Errorf("Features length mismatch: expected %d, got %d", len(original.Features), len(decoded.Features))
+	} else {
+		for i, feature := range original.Features {
+			if feature != decoded.Features[i] {
+				t.Errorf("Feature mismatch at index %d: expected %s, got %s", i, feature, decoded.Features[i])
+			}
+		}
+	}
+
+	// Check hardware binding
+	checkStringSlice(t, "MACAddresses", original.HardwareIDs.MACAddresses, decoded.HardwareIDs.MACAddresses)
+	checkStringSlice(t, "DiskIDs", original.HardwareIDs.DiskIDs, decoded.HardwareIDs.DiskIDs)
+	checkStringSlice(t, "HostNames", original.HardwareIDs.HostNames, decoded.HardwareIDs.HostNames)
+	checkStringSlice(t, "CustomIDs", original.HardwareIDs.CustomIDs, decoded.HardwareIDs.CustomIDs)
+}
+
+func checkStringSlice(t *testing.T, name string, expected, actual []string) {
+	if len(expected) != len(actual) {
+		t.Errorf("%s length mismatch: expected %d, got %d", name, len(expected), len(actual))
+		return
+	}
+	for i, item := range expected {
+		if item != actual[i] {
+			t.Errorf("%s mismatch at index %d: expected %s, got %s", name, i, item, actual[i])
+		}
+	}
+}
+
+func TestLicenseAdapter(t *testing.T) {
+	// Create a test license
+	original := &License{
+		ID:           "test-license-123",
+		CustomerID:   "customer-456",
+		ProductID:    "product-789",
+		SerialNumber: "SN-ABCDEF",
+		IssueDate:    time.Now().Truncate(time.Second),
+		ExpiryDate:   time.Now().AddDate(1, 0, 0).Truncate(time.Second),
+		Features:     []string{"feature1", "feature2", "feature3"},
+		HardwareIDs: HardwareBinding{
+			MACAddresses: []string{"00:11:22:33:44:55", "AA:BB:CC:DD:EE:FF"},
+			DiskIDs:      []string{"disk-id-1", "disk-id-2"},
+			HostNames:    []string{"host1.example.com", "host2.example.com"},
+			CustomIDs:    []string{"custom-id-1", "custom-id-2"},
+		},
+		Signature: []byte("test-signature"),
+	}
+
+	// Convert to LicenseData
+	data := ToLicenseData(original)
+
+	// Convert back to License
+	converted := FromLicenseData(data)
+
+	// Verify all fields match (except Signature which is not part of LicenseData)
+	if original.ID != converted.ID {
+		t.Errorf("ID mismatch: expected %s, got %s", original.ID, converted.ID)
+	}
+	if original.CustomerID != converted.CustomerID {
+		t.Errorf("CustomerID mismatch: expected %s, got %s", original.CustomerID, converted.CustomerID)
+	}
+	if original.ProductID != converted.ProductID {
+		t.Errorf("ProductID mismatch: expected %s, got %s", original.ProductID, converted.ProductID)
+	}
+	if original.SerialNumber != converted.SerialNumber {
+		t.Errorf("SerialNumber mismatch: expected %s, got %s", original.SerialNumber, converted.SerialNumber)
+	}
+	if !original.IssueDate.Equal(converted.IssueDate) {
+		t.Errorf("IssueDate mismatch: expected %v, got %v", original.IssueDate, converted.IssueDate)
+	}
+	if !original.ExpiryDate.Equal(converted.ExpiryDate) {
+		t.Errorf("ExpiryDate mismatch: expected %v, got %v", original.ExpiryDate, converted.ExpiryDate)
+	}
+
+	// Check features
+	checkStringSlice(t, "Features", original.Features, converted.Features)
+
+	// Check hardware binding
+	checkStringSlice(t, "MACAddresses", original.HardwareIDs.MACAddresses, converted.HardwareIDs.MACAddresses)
+	checkStringSlice(t, "DiskIDs", original.HardwareIDs.DiskIDs, converted.HardwareIDs.DiskIDs)
+	checkStringSlice(t, "HostNames", original.HardwareIDs.HostNames, converted.HardwareIDs.HostNames)
+	checkStringSlice(t, "CustomIDs", original.HardwareIDs.CustomIDs, converted.HardwareIDs.CustomIDs)
+}
+
+func TestEncodeLicense(t *testing.T) {
+	// Create a test license
+	license := &License{
+		ID:           "test-license-123",
+		CustomerID:   "customer-456",
+		ProductID:    "product-789",
+		SerialNumber: "SN-ABCDEF",
+		IssueDate:    time.Now().Truncate(time.Second),
+		ExpiryDate:   time.Now().AddDate(1, 0, 0).Truncate(time.Second),
+		Features:     []string{"feature1", "feature2", "feature3"},
+		HardwareIDs: HardwareBinding{
+			MACAddresses: []string{"00:11:22:33:44:55", "AA:BB:CC:DD:EE:FF"},
+			DiskIDs:      []string{"disk-id-1", "disk-id-2"},
+			HostNames:    []string{"host1.example.com", "host2.example.com"},
+			CustomIDs:    []string{"custom-id-1", "custom-id-2"},
+		},
+	}
+
+	// Encode to binary
+	binaryData, err := EncodeLicense(license)
+	if err != nil {
+		t.Fatalf("Failed to encode license: %v", err)
+	}
+
+	// Decode from binary
+	decoded, err := DecodeLicense(binaryData)
+	if err != nil {
+		t.Fatalf("Failed to decode license: %v", err)
+	}
+
+	// Verify all fields match
+	if license.ID != decoded.ID {
+		t.Errorf("ID mismatch: expected %s, got %s", license.ID, decoded.ID)
+	}
+	if license.CustomerID != decoded.CustomerID {
+		t.Errorf("CustomerID mismatch: expected %s, got %s", license.CustomerID, decoded.CustomerID)
+	}
+	if license.ProductID != decoded.ProductID {
+		t.Errorf("ProductID mismatch: expected %s, got %s", license.ProductID, decoded.ProductID)
+	}
+	if license.SerialNumber != decoded.SerialNumber {
+		t.Errorf("SerialNumber mismatch: expected %s, got %s", license.SerialNumber, decoded.SerialNumber)
+	}
+	if !license.IssueDate.Equal(decoded.IssueDate) {
+		t.Errorf("IssueDate mismatch: expected %v, got %v", license.IssueDate, decoded.IssueDate)
+	}
+	if !license.ExpiryDate.Equal(decoded.ExpiryDate) {
+		t.Errorf("ExpiryDate mismatch: expected %v, got %v", license.ExpiryDate, decoded.ExpiryDate)
+	}
+
+	// Check features
+	checkStringSlice(t, "Features", license.Features, decoded.Features)
+
+	// Check hardware binding
+	checkStringSlice(t, "MACAddresses", license.HardwareIDs.MACAddresses, decoded.HardwareIDs.MACAddresses)
+	checkStringSlice(t, "DiskIDs", license.HardwareIDs.DiskIDs, decoded.HardwareIDs.DiskIDs)
+	checkStringSlice(t, "HostNames", license.HardwareIDs.HostNames, decoded.HardwareIDs.HostNames)
+	checkStringSlice(t, "CustomIDs", license.HardwareIDs.CustomIDs, decoded.HardwareIDs.CustomIDs)
+}

--- a/pkg/licgen/license.go
+++ b/pkg/licgen/license.go
@@ -2,11 +2,11 @@ package licgen
 
 import (
 	"crypto/rsa"
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/luhtfiimanal/go-license/pkg/licformat"
 	"github.com/luhtfiimanal/go-license/pkg/licverify"
 )
 
@@ -33,10 +33,25 @@ func GenerateLicense(
 		HardwareIDs:  hardwareIDs,
 	}
 
-	// Marshal the license to JSON
-	licenseData, err := json.Marshal(license)
+	// Convert the license to binary format
+	licenseFormatObj := licformat.License{
+		ID:           license.ID,
+		CustomerID:   license.CustomerID,
+		ProductID:    license.ProductID,
+		SerialNumber: license.SerialNumber,
+		IssueDate:    license.IssueDate,
+		ExpiryDate:   license.ExpiryDate,
+		Features:     license.Features,
+		HardwareIDs: licformat.HardwareBinding{
+			MACAddresses: license.HardwareIDs.MACAddresses,
+			DiskIDs:      license.HardwareIDs.DiskIDs,
+			HostNames:    license.HardwareIDs.HostNames,
+			CustomIDs:    license.HardwareIDs.CustomIDs},
+	}
+
+	licenseData, err := licformat.EncodeLicense(&licenseFormatObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal license: %v", err)
+		return nil, fmt.Errorf("failed to encode license: %v", err)
 	}
 
 	// Sign the license


### PR DESCRIPTION
This major version update (v2.0.0) introduces several important changes:

Added:
- Binary license format for improved security and smaller file size
- Automatic hardware detection with --auto-hardware flag
- Backward compatibility for reading and verifying legacy JSON licenses

Changed:
- Licenses are now generated exclusively in binary format
- Updated verification to support both binary and legacy JSON formats
- Improved format detection in the info command
- Updated documentation to reflect the new binary format

Removed:
- JSON license generation option (only binary format is now supported)
- Encryption-related code (simplified the codebase)
- Unused Protocol Buffers definition file